### PR TITLE
fix: 태그 텍스트가 길어질 경우 깜빡이는 현상 개선 (#Dooray-QA/13636)

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -555,12 +555,12 @@ uis.controller('uiSelectCtrl',
             return false;
           }
           var inputWidth = containerWidth - input.offsetLeft - (ctrl.multiple ? 16 : 0);
-          if (inputWidth < 50) inputWidth = containerWidth;
+          if (inputWidth < 50) inputWidth = 50;
           ctrl.searchInput.css('width', inputWidth+'px');
           return true;
         };
 
-    ctrl.searchInput.css('width', '10px');
+    ctrl.searchInput.css('width', '50px');
     $timeout(function() { //Give tags time to render correctly
       if (sizeWatch === null && !updateIfVisible(calculateContainerWidth())) {
         sizeWatch = $scope.$watch(calculateContainerWidth, function(containerWidth) {


### PR DESCRIPTION
* [Task](https://nhnent.dooray.com/project/posts/2724469000855973239)

input 을 10px로 초기값을 설정하고 난 후에 다시 렌더링(`updateIfVisible`)할 때  inputWidth < 50인 경우 크기를 늘려버리는데, 이렇게 하면 input이 10 => 컨테이트 너비로 깜빡이게 된다. 최소값을 50으로 고정한다.